### PR TITLE
Add static plant index and coming soon pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# cream-roots# cream-roots
+# Brew City Roots
+
+This repository hosts a simple static web app for the Brew City Roots plant index.
+
+## Pages
+
+- `coming-soon.html` – landing page for the site.
+- `index.html` – interactive plant index with filtering and search.
+- `plant-profile.html` – template for displaying detailed information for a single plant.
+
+The plant data is stored in `plants.json` and loaded dynamically by `script.js`.

--- a/coming-soon.html
+++ b/coming-soon.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Brew City Roots - Coming Soon</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <style>
+        .coming-soon-container {
+            min-height: 80vh;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            text-align: center;
+        }
+        .coming-soon-container h1 {
+            font-size: 3rem;
+            color: #fff;
+            margin-bottom: 1rem;
+        }
+        .coming-soon-container p {
+            font-size: 1.2rem;
+            color: #c0c0c0;
+        }
+    </style>
+</head>
+<body>
+    <div class="background-shapes"></div>
+    <header>
+        <nav>
+            <div class="logo">Brew City Roots</div>
+            <ul>
+                <li><a href="coming-soon.html" class="active">Home</a></li>
+                <li><a href="index.html">Plant Index</a></li>
+                <li><a href="#">Care Guides</a></li>
+                <li><a href="#">Shop</a></li>
+                <li><a href="#">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main class="coming-soon-container">
+        <h1>Website Coming Soon</h1>
+        <p>We're cultivating something special. Stay tuned!</p>
+    </main>
+
+    <footer>
+        <p>&copy; 2024 Brew City Roots | Milwaukee, WI</p>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Plant Index - Brew City Roots</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="background-shapes"></div>
+    <header>
+        <nav>
+            <div class="logo">Brew City Roots</div>
+            <ul>
+                <li><a href="coming-soon.html">Home</a></li>
+                <li><a href="#" class="active">Plant Index</a></li>
+                <li><a href="#">Care Guides</a></li>
+                <li><a href="#">Shop</a></li>
+                <li><a href="#">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="hero">
+            <h1>The Brew City Roots Plant Index</h1>
+            <p>Your expert guide to a greener life. Discover, learn, and grow with us.</p>
+        </section>
+
+        <section class="filter-controls">
+            <select id="category-filter">
+                <option value="all">All Categories</option>
+                <option value="Trending Houseplant">Trending Houseplants</option>
+                <option value="Rare Collector's Plant">Rare Collector's Plants</option>
+                <option value="Milwaukee Hardy Perennial">Milwaukee Hardy Perennials</option>
+                <option value="Beginner Friendly">Beginner Friendly</option>
+                <option value="Pet Friendly">Pet Friendly</option>
+                <option value="Low Light">Low Light Tolerant</option>
+            </select>
+            <input type="text" id="search-bar" placeholder="Search for a plant...">
+        </section>
+
+        <section id="plant-grid" class="plant-grid-container">
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2024 Brew City Roots | Milwaukee, WI</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/plant-profile.html
+++ b/plant-profile.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Plant Profile - Brew City Roots</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <style>
+        /* Additional styles specific to the profile page */
+        .profile-container {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 3rem;
+            margin-top: 2rem;
+        }
+        .profile-image-container {
+            background: var(--card-background);
+            border: 1px solid var(--card-border);
+            border-radius: 16px;
+            padding: 1rem;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+        }
+        .profile-image {
+            width: 100%;
+            border-radius: 12px;
+        }
+        .profile-content {
+            background: var(--card-background);
+            border: 1px solid var(--card-border);
+            border-radius: 16px;
+            padding: 2rem;
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+        }
+        .profile-header h1 { font-size: 2.5rem; color: #fff; }
+        .profile-header h2 { font-size: 1.2rem; font-style: italic; color: #c0c0c0; margin-bottom: 1rem; }
+        .profile-summary { margin-bottom: 2rem; }
+        .profile-section { margin-bottom: 1.5rem; }
+        .profile-section h3 { font-size: 1.3rem; color: var(--accent-color); border-bottom: 1px solid var(--card-border); padding-bottom: 0.5rem; margin-bottom: 1rem; }
+        .care-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+        .care-item strong { color: #fff; }
+        @media (max-width: 900px) { .profile-container { grid-template-columns: 1fr; } }
+    </style>
+</head>
+<body>
+    <div class="background-shapes"></div>
+    <header>
+        <nav>
+            <div class="logo">Brew City Roots</div>
+            <ul>
+                <li><a href="coming-soon.html">Home</a></li>
+                <li><a href="index.html" class="active">Plant Index</a></li>
+                <li><a href="#">Care Guides</a></li>
+                <li><a href="#">Shop</a></li>
+                <li><a href="#">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main id="plant-profile-main">
+    </main>
+
+    <footer>
+        <p>&copy; 2024 Brew City Roots | Milwaukee, WI</p>
+    </footer>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', async () => {
+            const mainContent = document.getElementById('plant-profile-main');
+            const params = new URLSearchParams(window.location.search);
+            const plantId = params.get('id');
+
+            if (!plantId) {
+                mainContent.innerHTML = '<h1>Plant not found.</h1><p>Please return to the <a href="index.html">Plant Index</a>.</p>';
+                return;
+            }
+
+            try {
+                const response = await fetch('plants.json');
+                const plants = await response.json();
+                const plant = plants.find(p => p.id === plantId);
+
+                if (!plant) {
+                    mainContent.innerHTML = '<h1>Plant not found.</h1><p>Please return to the <a href="index.html">Plant Index</a>.</p>';
+                    return;
+                }
+
+                document.title = `${plant.commonName} - Brew City Roots`;
+                mainContent.innerHTML = `
+                    <div class="profile-container">
+                        <div class="profile-image-container">
+                            <img src="images/${plant.id}.jpg" alt="${plant.commonName}" class="profile-image">
+                        </div>
+                        <div class="profile-content">
+                            <div class="profile-header">
+                                <h1>${plant.commonName}</h1>
+                                <h2><em>${plant.scientificName}</em></h2>
+                            </div>
+                            <p class="profile-summary">${plant.summary}</p>
+                            
+                            <div class="profile-section">
+                                <h3>Origin</h3>
+                                <p><strong>Native Area:</strong> ${plant.origin.nativeArea}</p>
+                                <p><strong>History:</strong> ${plant.origin.history}</p>
+                            </div>
+
+                            <div class="profile-section">
+                                <h3>Care Regimen</h3>
+                                <div class="care-grid">
+                                    <div class="care-item"><strong>Light:</strong> ${plant.careRegimen.light}</div>
+                                    <div class="care-item"><strong>Water:</strong> ${plant.careRegimen.water}</div>
+                                    <div class="care-item"><strong>Soil:</strong> ${plant.careRegimen.soil.mix} (pH: ${plant.careRegimen.soil.ph})</div>
+                                    <div class="care-item"><strong>Temperature:</strong> ${plant.careRegimen.temperature.ideal}. ${plant.careRegimen.temperature.notes}</div>
+                                    <div class="care-item"><strong>Humidity:</strong> ${plant.careRegimen.humidity.level}. ${plant.careRegimen.humidity.tips}</div>
+                                    <div class="care-item"><strong>Fertilizer:</strong> ${plant.careRegimen.fertilizer}</div>
+                                </div>
+                                <p style="margin-top: 1rem;"><strong>Maintenance:</strong> ${plant.careRegimen.maintenance}</p>
+                            </div>
+
+                            <div class="profile-section">
+                                <h3>Symbiotic Relationships</h3>
+                                <p><strong>Indoor Companionship:</strong> ${plant.symbioticRelationships.indoor}</p>
+                                ${plant.symbioticRelationships.outdoor !== 'Not applicable for Milwaukee climate.' ? `<p><strong>Outdoor (Milwaukee):</strong> ${plant.symbioticRelationships.outdoor}</p>` : ''}
+                                <p><strong>Ecological Notes:</strong> ${plant.symbioticRelationships.ecologicalNotes}</p>
+                            </div>
+                        </div>
+                    </div>
+                `;
+
+            } catch (error) {
+                console.error('Error loading plant profile:', error);
+                mainContent.innerHTML = '<h1>Error</h1><p>Could not load plant details. Please try again.</p>';
+            }
+        });
+    </script>
+</body>
+</html>

--- a/plants.json
+++ b/plants.json
@@ -1,0 +1,1752 @@
+[
+  {
+    "id": "monstera-deliciosa",
+    "commonName": "Swiss Cheese Plant",
+    "scientificName": "Monstera deliciosa",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Swiss Cheese Plant.",
+    "origin": {
+      "nativeArea": "Native area for Swiss Cheese Plant.",
+      "history": "History of Swiss Cheese Plant."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Swiss Cheese Plant.",
+      "water": "Watering guidelines for Swiss Cheese Plant.",
+      "soil": {
+        "mix": "Well-draining soil mix for Swiss Cheese Plant.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Swiss Cheese Plant."
+    }
+  },
+  {
+    "id": "ficus-lyrata",
+    "commonName": "Fiddle Leaf Fig",
+    "scientificName": "Ficus lyrata",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Fiddle Leaf Fig.",
+    "origin": {
+      "nativeArea": "Native area for Fiddle Leaf Fig.",
+      "history": "History of Fiddle Leaf Fig."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Fiddle Leaf Fig.",
+      "water": "Watering guidelines for Fiddle Leaf Fig.",
+      "soil": {
+        "mix": "Well-draining soil mix for Fiddle Leaf Fig.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Fiddle Leaf Fig."
+    }
+  },
+  {
+    "id": "dracaena-trifasciata",
+    "commonName": "Snake Plant",
+    "scientificName": "Dracaena trifasciata",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Snake Plant.",
+    "origin": {
+      "nativeArea": "Native area for Snake Plant.",
+      "history": "History of Snake Plant."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Snake Plant.",
+      "water": "Watering guidelines for Snake Plant.",
+      "soil": {
+        "mix": "Well-draining soil mix for Snake Plant.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Snake Plant."
+    }
+  },
+  {
+    "id": "zamioculcas-zamiifolia",
+    "commonName": "ZZ Plant",
+    "scientificName": "Zamioculcas zamiifolia",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about ZZ Plant.",
+    "origin": {
+      "nativeArea": "Native area for ZZ Plant.",
+      "history": "History of ZZ Plant."
+    },
+    "careRegimen": {
+      "light": "Light requirements for ZZ Plant.",
+      "water": "Watering guidelines for ZZ Plant.",
+      "soil": {
+        "mix": "Well-draining soil mix for ZZ Plant.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of ZZ Plant."
+    }
+  },
+  {
+    "id": "epipremnum-aureum",
+    "commonName": "Golden Pothos",
+    "scientificName": "Epipremnum aureum",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Golden Pothos.",
+    "origin": {
+      "nativeArea": "Native area for Golden Pothos.",
+      "history": "History of Golden Pothos."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Golden Pothos.",
+      "water": "Watering guidelines for Golden Pothos.",
+      "soil": {
+        "mix": "Well-draining soil mix for Golden Pothos.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Golden Pothos."
+    }
+  },
+  {
+    "id": "philodendron-hederaceum",
+    "commonName": "Heartleaf Philodendron",
+    "scientificName": "Philodendron hederaceum",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Heartleaf Philodendron.",
+    "origin": {
+      "nativeArea": "Native area for Heartleaf Philodendron.",
+      "history": "History of Heartleaf Philodendron."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Heartleaf Philodendron.",
+      "water": "Watering guidelines for Heartleaf Philodendron.",
+      "soil": {
+        "mix": "Well-draining soil mix for Heartleaf Philodendron.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Heartleaf Philodendron."
+    }
+  },
+  {
+    "id": "stromanthe-triostar",
+    "commonName": "Stromanthe Triostar",
+    "scientificName": "Stromanthe sanguinea 'Triostar'",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Stromanthe Triostar.",
+    "origin": {
+      "nativeArea": "Native area for Stromanthe Triostar.",
+      "history": "History of Stromanthe Triostar."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Stromanthe Triostar.",
+      "water": "Watering guidelines for Stromanthe Triostar.",
+      "soil": {
+        "mix": "Well-draining soil mix for Stromanthe Triostar.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Stromanthe Triostar."
+    }
+  },
+  {
+    "id": "alocasia-baginda",
+    "commonName": "Dragon Scale Alocasia",
+    "scientificName": "Alocasia baginda 'Dragon Scale'",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Dragon Scale Alocasia.",
+    "origin": {
+      "nativeArea": "Native area for Dragon Scale Alocasia.",
+      "history": "History of Dragon Scale Alocasia."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Dragon Scale Alocasia.",
+      "water": "Watering guidelines for Dragon Scale Alocasia.",
+      "soil": {
+        "mix": "Well-draining soil mix for Dragon Scale Alocasia.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Dragon Scale Alocasia."
+    }
+  },
+  {
+    "id": "hoya-carnosa",
+    "commonName": "Wax Plant",
+    "scientificName": "Hoya carnosa",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Wax Plant.",
+    "origin": {
+      "nativeArea": "Native area for Wax Plant.",
+      "history": "History of Wax Plant."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Wax Plant.",
+      "water": "Watering guidelines for Wax Plant.",
+      "soil": {
+        "mix": "Well-draining soil mix for Wax Plant.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Wax Plant."
+    }
+  },
+  {
+    "id": "calathea-orbifolia",
+    "commonName": "Calathea Orbifolia",
+    "scientificName": "Goeppertia orbifolia",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Calathea Orbifolia.",
+    "origin": {
+      "nativeArea": "Native area for Calathea Orbifolia.",
+      "history": "History of Calathea Orbifolia."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Calathea Orbifolia.",
+      "water": "Watering guidelines for Calathea Orbifolia.",
+      "soil": {
+        "mix": "Well-draining soil mix for Calathea Orbifolia.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Calathea Orbifolia."
+    }
+  },
+  {
+    "id": "strelitzia-nicolai",
+    "commonName": "White Bird of Paradise",
+    "scientificName": "Strelitzia nicolai",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor/Outdoor",
+    "summary": "Basic information about White Bird of Paradise.",
+    "origin": {
+      "nativeArea": "Native area for White Bird of Paradise.",
+      "history": "History of White Bird of Paradise."
+    },
+    "careRegimen": {
+      "light": "Light requirements for White Bird of Paradise.",
+      "water": "Watering guidelines for White Bird of Paradise.",
+      "soil": {
+        "mix": "Well-draining soil mix for White Bird of Paradise.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of White Bird of Paradise."
+    }
+  },
+  {
+    "id": "dypsis-lutescens",
+    "commonName": "Areca Palm",
+    "scientificName": "Dypsis lutescens",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Areca Palm.",
+    "origin": {
+      "nativeArea": "Native area for Areca Palm.",
+      "history": "History of Areca Palm."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Areca Palm.",
+      "water": "Watering guidelines for Areca Palm.",
+      "soil": {
+        "mix": "Well-draining soil mix for Areca Palm.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Areca Palm."
+    }
+  },
+  {
+    "id": "ficus-elastica-tineke",
+    "commonName": "Variegated Rubber Plant",
+    "scientificName": "Ficus elastica 'Tineke'",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Variegated Rubber Plant.",
+    "origin": {
+      "nativeArea": "Native area for Variegated Rubber Plant.",
+      "history": "History of Variegated Rubber Plant."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Variegated Rubber Plant.",
+      "water": "Watering guidelines for Variegated Rubber Plant.",
+      "soil": {
+        "mix": "Well-draining soil mix for Variegated Rubber Plant.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Variegated Rubber Plant."
+    }
+  },
+  {
+    "id": "chlorophytum-comosum",
+    "commonName": "Spider Plant",
+    "scientificName": "Chlorophytum comosum",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Spider Plant.",
+    "origin": {
+      "nativeArea": "Native area for Spider Plant.",
+      "history": "History of Spider Plant."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Spider Plant.",
+      "water": "Watering guidelines for Spider Plant.",
+      "soil": {
+        "mix": "Well-draining soil mix for Spider Plant.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Spider Plant."
+    }
+  },
+  {
+    "id": "spathiphyllum-wallisii",
+    "commonName": "Peace Lily",
+    "scientificName": "Spathiphyllum wallisii",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Peace Lily.",
+    "origin": {
+      "nativeArea": "Native area for Peace Lily.",
+      "history": "History of Peace Lily."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Peace Lily.",
+      "water": "Watering guidelines for Peace Lily.",
+      "soil": {
+        "mix": "Well-draining soil mix for Peace Lily.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Peace Lily."
+    }
+  },
+  {
+    "id": "philodendron-birkin",
+    "commonName": "Philodendron Birkin",
+    "scientificName": "Philodendron 'Birkin'",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Philodendron Birkin.",
+    "origin": {
+      "nativeArea": "Native area for Philodendron Birkin.",
+      "history": "History of Philodendron Birkin."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Philodendron Birkin.",
+      "water": "Watering guidelines for Philodendron Birkin.",
+      "soil": {
+        "mix": "Well-draining soil mix for Philodendron Birkin.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Philodendron Birkin."
+    }
+  },
+  {
+    "id": "epipremnum-pinnatum-cebu",
+    "commonName": "Cebu Blue Pothos",
+    "scientificName": "Epipremnum pinnatum 'Cebu Blue'",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Cebu Blue Pothos.",
+    "origin": {
+      "nativeArea": "Native area for Cebu Blue Pothos.",
+      "history": "History of Cebu Blue Pothos."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Cebu Blue Pothos.",
+      "water": "Watering guidelines for Cebu Blue Pothos.",
+      "soil": {
+        "mix": "Well-draining soil mix for Cebu Blue Pothos.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Cebu Blue Pothos."
+    }
+  },
+  {
+    "id": "curio-rowleyanus",
+    "commonName": "String of Pearls",
+    "scientificName": "Curio rowleyanus",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about String of Pearls.",
+    "origin": {
+      "nativeArea": "Native area for String of Pearls.",
+      "history": "History of String of Pearls."
+    },
+    "careRegimen": {
+      "light": "Light requirements for String of Pearls.",
+      "water": "Watering guidelines for String of Pearls.",
+      "soil": {
+        "mix": "Well-draining soil mix for String of Pearls.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of String of Pearls."
+    }
+  },
+  {
+    "id": "saintpaulia-ionantha",
+    "commonName": "African Violet",
+    "scientificName": "Saintpaulia ionantha",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about African Violet.",
+    "origin": {
+      "nativeArea": "Native area for African Violet.",
+      "history": "History of African Violet."
+    },
+    "careRegimen": {
+      "light": "Light requirements for African Violet.",
+      "water": "Watering guidelines for African Violet.",
+      "soil": {
+        "mix": "Well-draining soil mix for African Violet.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of African Violet."
+    }
+  },
+  {
+    "id": "aspidistra-elatior",
+    "commonName": "Cast Iron Plant",
+    "scientificName": "Aspidistra elatior",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Cast Iron Plant.",
+    "origin": {
+      "nativeArea": "Native area for Cast Iron Plant.",
+      "history": "History of Cast Iron Plant."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Cast Iron Plant.",
+      "water": "Watering guidelines for Cast Iron Plant.",
+      "soil": {
+        "mix": "Well-draining soil mix for Cast Iron Plant.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Cast Iron Plant."
+    }
+  },
+  {
+    "id": "ficus-benghalensis",
+    "commonName": "Ficus Audrey",
+    "scientificName": "Ficus benghalensis 'Audrey'",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Ficus Audrey.",
+    "origin": {
+      "nativeArea": "Native area for Ficus Audrey.",
+      "history": "History of Ficus Audrey."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Ficus Audrey.",
+      "water": "Watering guidelines for Ficus Audrey.",
+      "soil": {
+        "mix": "Well-draining soil mix for Ficus Audrey.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Ficus Audrey."
+    }
+  },
+  {
+    "id": "pachira-aquatica",
+    "commonName": "Money Tree",
+    "scientificName": "Pachira aquatica",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Money Tree.",
+    "origin": {
+      "nativeArea": "Native area for Money Tree.",
+      "history": "History of Money Tree."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Money Tree.",
+      "water": "Watering guidelines for Money Tree.",
+      "soil": {
+        "mix": "Well-draining soil mix for Money Tree.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Money Tree."
+    }
+  },
+  {
+    "id": "phalaenopsis-orchid",
+    "commonName": "Moth Orchid",
+    "scientificName": "Phalaenopsis spp.",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Moth Orchid.",
+    "origin": {
+      "nativeArea": "Native area for Moth Orchid.",
+      "history": "History of Moth Orchid."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Moth Orchid.",
+      "water": "Watering guidelines for Moth Orchid.",
+      "soil": {
+        "mix": "Well-draining soil mix for Moth Orchid.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Moth Orchid."
+    }
+  },
+  {
+    "id": "dracaena-marginata",
+    "commonName": "Dragon Tree",
+    "scientificName": "Dracaena marginata",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Dragon Tree.",
+    "origin": {
+      "nativeArea": "Native area for Dragon Tree.",
+      "history": "History of Dragon Tree."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Dragon Tree.",
+      "water": "Watering guidelines for Dragon Tree.",
+      "soil": {
+        "mix": "Well-draining soil mix for Dragon Tree.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Dragon Tree."
+    }
+  },
+  {
+    "id": "crassula-ovata",
+    "commonName": "Jade Plant",
+    "scientificName": "Crassula ovata",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Jade Plant.",
+    "origin": {
+      "nativeArea": "Native area for Jade Plant.",
+      "history": "History of Jade Plant."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Jade Plant.",
+      "water": "Watering guidelines for Jade Plant.",
+      "soil": {
+        "mix": "Well-draining soil mix for Jade Plant.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Jade Plant."
+    }
+  },
+  {
+    "id": "aloe-barbadensis-miller",
+    "commonName": "Aloe Vera",
+    "scientificName": "Aloe barbadensis miller",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor/Outdoor",
+    "summary": "Basic information about Aloe Vera.",
+    "origin": {
+      "nativeArea": "Native area for Aloe Vera.",
+      "history": "History of Aloe Vera."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Aloe Vera.",
+      "water": "Watering guidelines for Aloe Vera.",
+      "soil": {
+        "mix": "Well-draining soil mix for Aloe Vera.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Aloe Vera."
+    }
+  },
+  {
+    "id": "tillandsia-ionantha",
+    "commonName": "Air Plant",
+    "scientificName": "Tillandsia ionantha",
+    "category": "Trending Houseplant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Air Plant.",
+    "origin": {
+      "nativeArea": "Native area for Air Plant.",
+      "history": "History of Air Plant."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Air Plant.",
+      "water": "Watering guidelines for Air Plant.",
+      "soil": {
+        "mix": "Well-draining soil mix for Air Plant.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Air Plant."
+    }
+  },
+  {
+    "id": "monstera-esqueleto",
+    "commonName": "Monstera Esqueleto",
+    "scientificName": "Monstera epipremnoides",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Monstera Esqueleto.",
+    "origin": {
+      "nativeArea": "Native area for Monstera Esqueleto.",
+      "history": "History of Monstera Esqueleto."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Monstera Esqueleto.",
+      "water": "Watering guidelines for Monstera Esqueleto.",
+      "soil": {
+        "mix": "Well-draining soil mix for Monstera Esqueleto.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Monstera Esqueleto."
+    }
+  },
+  {
+    "id": "monstera-thai-constellation",
+    "commonName": "Thai Constellation Monstera",
+    "scientificName": "Monstera deliciosa 'Thai Constellation'",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Thai Constellation Monstera.",
+    "origin": {
+      "nativeArea": "Native area for Thai Constellation Monstera.",
+      "history": "History of Thai Constellation Monstera."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Thai Constellation Monstera.",
+      "water": "Watering guidelines for Thai Constellation Monstera.",
+      "soil": {
+        "mix": "Well-draining soil mix for Thai Constellation Monstera.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Thai Constellation Monstera."
+    }
+  },
+  {
+    "id": "monstera-albo-borsigiana",
+    "commonName": "Albo Monstera",
+    "scientificName": "Monstera deliciosa 'Albo Borsigiana'",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Albo Monstera.",
+    "origin": {
+      "nativeArea": "Native area for Albo Monstera.",
+      "history": "History of Albo Monstera."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Albo Monstera.",
+      "water": "Watering guidelines for Albo Monstera.",
+      "soil": {
+        "mix": "Well-draining soil mix for Albo Monstera.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Albo Monstera."
+    }
+  },
+  {
+    "id": "alocasia-frydek-variegata",
+    "commonName": "Variegated Frydek",
+    "scientificName": "Alocasia micholitziana 'Frydek' Variegata",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Variegated Frydek.",
+    "origin": {
+      "nativeArea": "Native area for Variegated Frydek.",
+      "history": "History of Variegated Frydek."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Variegated Frydek.",
+      "water": "Watering guidelines for Variegated Frydek.",
+      "soil": {
+        "mix": "Well-draining soil mix for Variegated Frydek.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Variegated Frydek."
+    }
+  },
+  {
+    "id": "philodendron-pink-princess",
+    "commonName": "Pink Princess Philodendron",
+    "scientificName": "Philodendron erubescens 'Pink Princess'",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Pink Princess Philodendron.",
+    "origin": {
+      "nativeArea": "Native area for Pink Princess Philodendron.",
+      "history": "History of Pink Princess Philodendron."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Pink Princess Philodendron.",
+      "water": "Watering guidelines for Pink Princess Philodendron.",
+      "soil": {
+        "mix": "Well-draining soil mix for Pink Princess Philodendron.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Pink Princess Philodendron."
+    }
+  },
+  {
+    "id": "philodendron-florida-ghost",
+    "commonName": "Florida Ghost Philodendron",
+    "scientificName": "Philodendron 'Florida Ghost'",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Florida Ghost Philodendron.",
+    "origin": {
+      "nativeArea": "Native area for Florida Ghost Philodendron.",
+      "history": "History of Florida Ghost Philodendron."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Florida Ghost Philodendron.",
+      "water": "Watering guidelines for Florida Ghost Philodendron.",
+      "soil": {
+        "mix": "Well-draining soil mix for Florida Ghost Philodendron.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Florida Ghost Philodendron."
+    }
+  },
+  {
+    "id": "philodendron-gloriosum",
+    "commonName": "Philodendron Gloriosum",
+    "scientificName": "Philodendron gloriosum",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Philodendron Gloriosum.",
+    "origin": {
+      "nativeArea": "Native area for Philodendron Gloriosum.",
+      "history": "History of Philodendron Gloriosum."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Philodendron Gloriosum.",
+      "water": "Watering guidelines for Philodendron Gloriosum.",
+      "soil": {
+        "mix": "Well-draining soil mix for Philodendron Gloriosum.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Philodendron Gloriosum."
+    }
+  },
+  {
+    "id": "philodendron-melanochrysum",
+    "commonName": "Black Gold Philodendron",
+    "scientificName": "Philodendron melanochrysum",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Black Gold Philodendron.",
+    "origin": {
+      "nativeArea": "Native area for Black Gold Philodendron.",
+      "history": "History of Black Gold Philodendron."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Black Gold Philodendron.",
+      "water": "Watering guidelines for Black Gold Philodendron.",
+      "soil": {
+        "mix": "Well-draining soil mix for Black Gold Philodendron.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Black Gold Philodendron."
+    }
+  },
+  {
+    "id": "anthurium-warocqueanum",
+    "commonName": "Queen Anthurium",
+    "scientificName": "Anthurium warocqueanum",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Queen Anthurium.",
+    "origin": {
+      "nativeArea": "Native area for Queen Anthurium.",
+      "history": "History of Queen Anthurium."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Queen Anthurium.",
+      "water": "Watering guidelines for Queen Anthurium.",
+      "soil": {
+        "mix": "Well-draining soil mix for Queen Anthurium.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Queen Anthurium."
+    }
+  },
+  {
+    "id": "alocasia-azlanii",
+    "commonName": "Red Mambo Alocasia",
+    "scientificName": "Alocasia azlanii",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Red Mambo Alocasia.",
+    "origin": {
+      "nativeArea": "Native area for Red Mambo Alocasia.",
+      "history": "History of Red Mambo Alocasia."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Red Mambo Alocasia.",
+      "water": "Watering guidelines for Red Mambo Alocasia.",
+      "soil": {
+        "mix": "Well-draining soil mix for Red Mambo Alocasia.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Red Mambo Alocasia."
+    }
+  },
+  {
+    "id": "philodendron-spiritus-sancti",
+    "commonName": "Philodendron Spiritus Sancti",
+    "scientificName": "Philodendron spiritus-sancti",
+    "category": "Rare Collector's Plant",
+    "primaryEnvironment": "Indoor",
+    "summary": "Basic information about Philodendron Spiritus Sancti.",
+    "origin": {
+      "nativeArea": "Native area for Philodendron Spiritus Sancti.",
+      "history": "History of Philodendron Spiritus Sancti."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Philodendron Spiritus Sancti.",
+      "water": "Watering guidelines for Philodendron Spiritus Sancti.",
+      "soil": {
+        "mix": "Well-draining soil mix for Philodendron Spiritus Sancti.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Not applicable for Milwaukee climate.",
+      "ecologicalNotes": "Ecological role of Philodendron Spiritus Sancti."
+    }
+  },
+  {
+    "id": "echinacea-purpurea",
+    "commonName": "Purple Coneflower",
+    "scientificName": "Echinacea purpurea",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Purple Coneflower.",
+    "origin": {
+      "nativeArea": "Native area for Purple Coneflower.",
+      "history": "History of Purple Coneflower."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Purple Coneflower.",
+      "water": "Watering guidelines for Purple Coneflower.",
+      "soil": {
+        "mix": "Well-draining soil mix for Purple Coneflower.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Purple Coneflower."
+    }
+  },
+  {
+    "id": "rudbeckia-hirta",
+    "commonName": "Black-Eyed Susan",
+    "scientificName": "Rudbeckia hirta",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Black-Eyed Susan.",
+    "origin": {
+      "nativeArea": "Native area for Black-Eyed Susan.",
+      "history": "History of Black-Eyed Susan."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Black-Eyed Susan.",
+      "water": "Watering guidelines for Black-Eyed Susan.",
+      "soil": {
+        "mix": "Well-draining soil mix for Black-Eyed Susan.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Black-Eyed Susan."
+    }
+  },
+  {
+    "id": "panicum-virgatum-shenandoah",
+    "commonName": "Shenandoah Switchgrass",
+    "scientificName": "Panicum virgatum 'Shenandoah'",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Shenandoah Switchgrass.",
+    "origin": {
+      "nativeArea": "Native area for Shenandoah Switchgrass.",
+      "history": "History of Shenandoah Switchgrass."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Shenandoah Switchgrass.",
+      "water": "Watering guidelines for Shenandoah Switchgrass.",
+      "soil": {
+        "mix": "Well-draining soil mix for Shenandoah Switchgrass.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Shenandoah Switchgrass."
+    }
+  },
+  {
+    "id": "hosta-patriot",
+    "commonName": "Patriot Hosta",
+    "scientificName": "Hosta 'Patriot'",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Patriot Hosta.",
+    "origin": {
+      "nativeArea": "Native area for Patriot Hosta.",
+      "history": "History of Patriot Hosta."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Patriot Hosta.",
+      "water": "Watering guidelines for Patriot Hosta.",
+      "soil": {
+        "mix": "Well-draining soil mix for Patriot Hosta.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Patriot Hosta."
+    }
+  },
+  {
+    "id": "hemerocallis-stella-de-oro",
+    "commonName": "Stella de Oro Daylily",
+    "scientificName": "Hemerocallis 'Stella de Oro'",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Stella de Oro Daylily.",
+    "origin": {
+      "nativeArea": "Native area for Stella de Oro Daylily.",
+      "history": "History of Stella de Oro Daylily."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Stella de Oro Daylily.",
+      "water": "Watering guidelines for Stella de Oro Daylily.",
+      "soil": {
+        "mix": "Well-draining soil mix for Stella de Oro Daylily.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Stella de Oro Daylily."
+    }
+  },
+  {
+    "id": "hylotelephium-autumn-joy",
+    "commonName": "Autumn Joy Sedum",
+    "scientificName": "Hylotelephium 'Herbstfreude' (Autumn Joy)",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Autumn Joy Sedum.",
+    "origin": {
+      "nativeArea": "Native area for Autumn Joy Sedum.",
+      "history": "History of Autumn Joy Sedum."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Autumn Joy Sedum.",
+      "water": "Watering guidelines for Autumn Joy Sedum.",
+      "soil": {
+        "mix": "Well-draining soil mix for Autumn Joy Sedum.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Autumn Joy Sedum."
+    }
+  },
+  {
+    "id": "salvia-nemorosa-may-night",
+    "commonName": "May Night Salvia",
+    "scientificName": "Salvia nemorosa 'Mainacht' (May Night)",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about May Night Salvia.",
+    "origin": {
+      "nativeArea": "Native area for May Night Salvia.",
+      "history": "History of May Night Salvia."
+    },
+    "careRegimen": {
+      "light": "Light requirements for May Night Salvia.",
+      "water": "Watering guidelines for May Night Salvia.",
+      "soil": {
+        "mix": "Well-draining soil mix for May Night Salvia.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of May Night Salvia."
+    }
+  },
+  {
+    "id": "astilbe-fanal",
+    "commonName": "Fanal Astilbe",
+    "scientificName": "Astilbe x arendsii 'Fanal'",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Fanal Astilbe.",
+    "origin": {
+      "nativeArea": "Native area for Fanal Astilbe.",
+      "history": "History of Fanal Astilbe."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Fanal Astilbe.",
+      "water": "Watering guidelines for Fanal Astilbe.",
+      "soil": {
+        "mix": "Well-draining soil mix for Fanal Astilbe.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Fanal Astilbe."
+    }
+  },
+  {
+    "id": "nepeta-faassenii-walkers-low",
+    "commonName": "Walker's Low Catmint",
+    "scientificName": "Nepeta x faassenii 'Walker's Low'",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Walker's Low Catmint.",
+    "origin": {
+      "nativeArea": "Native area for Walker's Low Catmint.",
+      "history": "History of Walker's Low Catmint."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Walker's Low Catmint.",
+      "water": "Watering guidelines for Walker's Low Catmint.",
+      "soil": {
+        "mix": "Well-draining soil mix for Walker's Low Catmint.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Walker's Low Catmint."
+    }
+  },
+  {
+    "id": "lamprocapnos-spectabilis",
+    "commonName": "Bleeding Heart",
+    "scientificName": "Lamprocapnos spectabilis",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Bleeding Heart.",
+    "origin": {
+      "nativeArea": "Native area for Bleeding Heart.",
+      "history": "History of Bleeding Heart."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Bleeding Heart.",
+      "water": "Watering guidelines for Bleeding Heart.",
+      "soil": {
+        "mix": "Well-draining soil mix for Bleeding Heart.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Bleeding Heart."
+    }
+  },
+  {
+    "id": "athyrium-niponicum-pictum",
+    "commonName": "Japanese Painted Fern",
+    "scientificName": "Athyrium niponicum var. pictum",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Japanese Painted Fern.",
+    "origin": {
+      "nativeArea": "Native area for Japanese Painted Fern.",
+      "history": "History of Japanese Painted Fern."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Japanese Painted Fern.",
+      "water": "Watering guidelines for Japanese Painted Fern.",
+      "soil": {
+        "mix": "Well-draining soil mix for Japanese Painted Fern.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Japanese Painted Fern."
+    }
+  },
+  {
+    "id": "paeonia-lactiflora-sarah",
+    "commonName": "Sarah Bernhardt Peony",
+    "scientificName": "Paeonia lactiflora 'Sarah Bernhardt'",
+    "category": "Milwaukee Hardy Perennial",
+    "primaryEnvironment": "Outdoor",
+    "summary": "Basic information about Sarah Bernhardt Peony.",
+    "origin": {
+      "nativeArea": "Native area for Sarah Bernhardt Peony.",
+      "history": "History of Sarah Bernhardt Peony."
+    },
+    "careRegimen": {
+      "light": "Light requirements for Sarah Bernhardt Peony.",
+      "water": "Watering guidelines for Sarah Bernhardt Peony.",
+      "soil": {
+        "mix": "Well-draining soil mix for Sarah Bernhardt Peony.",
+        "ph": "6.0 - 7.0"
+      },
+      "temperature": {
+        "ideal": "65-85\u00b0F (18-29\u00b0C)",
+        "notes": "Protect from extreme temperatures."
+      },
+      "humidity": {
+        "level": "Moderate humidity.",
+        "tips": "Increase humidity if air is very dry."
+      },
+      "fertilizer": "Feed monthly during growing season.",
+      "maintenance": "Remove dead or yellowing leaves as needed."
+    },
+    "symbioticRelationships": {
+      "indoor": "Pairs well with other plants in similar conditions.",
+      "outdoor": "Combine with other native perennials for pollinator support.",
+      "ecologicalNotes": "Ecological role of Sarah Bernhardt Peony."
+    }
+  }
+]

--- a/script.js
+++ b/script.js
@@ -1,0 +1,68 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const plantGrid = document.getElementById('plant-grid');
+    const categoryFilter = document.getElementById('category-filter');
+    const searchBar = document.getElementById('search-bar');
+    let allPlantsData = [];
+
+    async function fetchPlantData() {
+        try {
+            const response = await fetch('plants.json');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            allPlantsData = await response.json();
+            renderPlantCards(allPlantsData);
+        } catch (error) {
+            console.error('Could not fetch plant data:', error);
+            plantGrid.innerHTML = '<p>Error loading plant data. Please try again later.</p>';
+        }
+    }
+
+    function renderPlantCards(plants) {
+        plantGrid.innerHTML = '';
+        if (plants.length === 0) {
+            plantGrid.innerHTML = '<p>No plants match your criteria.</p>';
+            return;
+        }
+        plants.forEach(plant => {
+            const card = document.createElement('a');
+            card.href = `plant-profile.html?id=${plant.id}`;
+            card.className = 'plant-card';
+            card.innerHTML = `
+                <img src="images/${plant.id}.jpg" alt="${plant.commonName}" class="plant-card-img" loading="lazy">
+                <div class="plant-card-content">
+                    <h3>${plant.commonName}</h3>
+                    <p><em>${plant.scientificName}</em></p>
+                </div>
+            `;
+            plantGrid.appendChild(card);
+        });
+    }
+
+    function filterPlants() {
+        const selectedCategory = categoryFilter.value;
+        const searchTerm = searchBar.value.toLowerCase();
+
+        let filteredPlants = allPlantsData;
+
+        if (selectedCategory !== 'all') {
+            filteredPlants = filteredPlants.filter(plant =>
+                plant.category.includes(selectedCategory)
+            );
+        }
+
+        if (searchTerm) {
+            filteredPlants = filteredPlants.filter(plant =>
+                plant.commonName.toLowerCase().includes(searchTerm) ||
+                plant.scientificName.toLowerCase().includes(searchTerm)
+            );
+        }
+
+        renderPlantCards(filteredPlants);
+    }
+
+    categoryFilter.addEventListener('change', filterPlants);
+    searchBar.addEventListener('input', filterPlants);
+
+    fetchPlantData();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,175 @@
+:root {
+    --primary-font: 'Inter', sans-serif;
+    --text-color: #E0E0E0;
+    --background-color: #1a1a1d;
+    --card-background: rgba(255, 255, 255, 0.1);
+    --card-border: rgba(255, 255, 255, 0.2);
+    --accent-color: #4CAF50;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: var(--primary-font);
+    background-color: var(--background-color);
+    color: var(--text-color);
+    line-height: 1.6;
+    overflow-x: hidden;
+    position: relative;
+}
+
+.background-shapes {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    background: 
+        radial-gradient(circle at 15% 25%, rgba(76, 175, 80, 0.2), transparent 40%),
+        radial-gradient(circle at 85% 75%, rgba(33, 150, 243, 0.15), transparent 40%);
+    animation: move-gradient 20s ease-in-out infinite;
+}
+
+@keyframes move-gradient {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
+}
+
+header {
+    padding: 1rem 5%;
+    border-bottom: 1px solid var(--card-border);
+}
+
+nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 1400px;
+    margin: 0 auto;
+}
+
+.logo {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+nav ul {
+    list-style: none;
+    display: flex;
+    gap: 2rem;
+}
+
+nav a {
+    text-decoration: none;
+    color: var(--text-color);
+    font-weight: 500;
+    transition: color 0.3s ease;
+}
+
+nav a:hover, nav a.active {
+    color: var(--accent-color);
+}
+
+main {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 2rem 5%;
+}
+
+.hero {
+    text-align: center;
+    padding: 3rem 0;
+}
+
+.hero h1 {
+    font-size: 3rem;
+    margin-bottom: 0.5rem;
+    color: #fff;
+}
+
+.filter-controls {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-bottom: 3rem;
+}
+
+.filter-controls select,
+.filter-controls input {
+    background: var(--card-background);
+    border: 1px solid var(--card-border);
+    color: var(--text-color);
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    font-family: var(--primary-font);
+    font-size: 1rem;
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+}
+
+.filter-controls input::placeholder {
+    color: #a0a0a0;
+}
+
+.plant-grid-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 2rem;
+}
+
+.plant-card {
+    background: var(--card-background);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.2);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    text-decoration: none;
+    color: var(--text-color);
+    display: flex;
+    flex-direction: column;
+}
+
+.plant-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 12px 40px 0 rgba(0, 0, 0, 0.3);
+}
+
+.plant-card-img {
+    width: 100%;
+    height: 250px;
+    object-fit: cover;
+}
+
+.plant-card-content {
+    padding: 1.5rem;
+    flex-grow: 1;
+}
+
+.plant-card-content h3 {
+    font-size: 1.25rem;
+    color: #fff;
+    margin-bottom: 0.25rem;
+}
+
+.plant-card-content p {
+    font-style: italic;
+    font-size: 0.9rem;
+    color: #c0c0c0;
+}
+
+footer {
+    text-align: center;
+    padding: 2rem 5%;
+    margin-top: 3rem;
+    border-top: 1px solid var(--card-border);
+}


### PR DESCRIPTION
## Summary
- set up glassmorphic "Coming Soon" landing page and navigation
- add interactive plant index with search/filter and individual plant profile template
- include placeholder dataset for 50 plants and shared styling/scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a030b194d48328ab1ee1166f0e1dec